### PR TITLE
Add Hoisting to t.interface method, allowing cross-reference/recursive types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,39 @@ export interface Organization {
   members: Array<Member>;
 }
 ```
+
+### What about interfaces that reference themselves, or cross-reference each other?
+
+Passing in a callback to the `t.interface` method will lazily populate the interface with its returned values. This will ensure that you can self-reference or cross-reference the interface, and it will be available by generation.
+
+```ts
+import { t } from "tanu.js";
+
+const User = t.interface("User", () => {
+  return {
+    users: t.array(User),
+    posts: t.array(Post),
+  };
+});
+
+const Post = t.interface("Post", () => {
+  return {
+    author: User,
+  };
+});
+
+const result = await t.generate([User, Post]);
+console.log(result);
+```
+
+```ts
+// the generated result
+
+export interface User {
+  users: Array<User>;
+  posts: Array<Post>;
+}
+export interface Post {
+  author: User;
+}
+```

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -8,5 +8,19 @@ export async function generate(nodes: Array<ts.Node>): Promise<string> {
 	const file = ts.createSourceFile("", "", ts.ScriptTarget.ESNext, true);
 	const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
 
-	return printer.printList(ts.ListFormat.MultiLine, ts.factory.createNodeArray(nodes), file);
+	return new Promise((resolve, reject) => {
+		try {
+			setImmediate(() => {
+				const printedNodes = printer.printList(
+					ts.ListFormat.MultiLine,
+					ts.factory.createNodeArray(nodes),
+					file
+				);
+
+				resolve(printedNodes);
+			});
+		} catch (error) {
+			reject(error);
+		}
+	});
 }

--- a/src/type/declarations/interface.ts
+++ b/src/type/declarations/interface.ts
@@ -4,18 +4,9 @@ import { TypeDefinitionObject } from "..";
 import { typeProperty } from "../utils";
 
 /**
- * "interface" is a reserved keyword.
+ * Constructs an interface with the given name and properties.
  */
-export { interface_ as interface };
-
-/**
- * Create an interface. Used to describe the shape
- * of objects, and can be extended by others.
- *
- * @param name The name of the interface.
- * @param properties An object, with type definitions as values.
- */
-function interface_(name: string, properties: TypeDefinitionObject): ts.InterfaceDeclaration {
+function constructInterface(name: string, properties: TypeDefinitionObject) {
 	return ts.factory.createInterfaceDeclaration(
 		undefined,
 		[ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
@@ -26,4 +17,34 @@ function interface_(name: string, properties: TypeDefinitionObject): ts.Interfac
 			return typeProperty(key, node);
 		})
 	);
+}
+
+/**
+ * "interface" is a reserved keyword.
+ */
+export { interface_ as interface };
+
+/**
+ * Create an interface. Used to describe the shape
+ * of objects, and can be extended by others.
+ *
+ * @param name The name of the interface.
+ * @param properties An object, with type definitions as values or a function which lazily returns them.
+ */
+function interface_(
+	name: string,
+	properties: TypeDefinitionObject | (() => TypeDefinitionObject)
+): ts.InterfaceDeclaration {
+	if (typeof properties !== "function") return constructInterface(name, properties);
+
+	let tentativeInterface = constructInterface(name, {});
+	setImmediate(() => {
+		tentativeInterface = constructInterface(name, properties());
+	});
+
+	return new Proxy(tentativeInterface, {
+		get(_, property, receiver) {
+			return Reflect.get(tentativeInterface, property, receiver);
+		}
+	});
 }


### PR DESCRIPTION
This allows for circular, and cross-references by leveraging the option to provide a callback, `setImmediate`, and `Proxy`. 

## Code

```ts
import { t } from "tanu.js";

const User = t.interface("User", () => ({
  users: t.array(User),
  posts: t.array(Post),
  authoredComments: t.array(Comment),
}));

const Post = t.interface("Post", () => ({
  author: User,
  text: t.string(),
  images: t.array(t.string()),
  postComments: t.array(Comment),
}));

const Comment = t.interface("Comment", {
  author: User,
  post: Post,
  text: t.string(),
});

const result = await t.generate([User, Post]);
console.log(result);
```

## Produces

```ts
export interface User {
    users: Array<User>;
    posts: Array<Post>;
    authoredComments: Array<Comment>;
}
export interface Post {
    author: User;
    text: string;
    images: Array<string>;
    postComments: Array<Comment>;
}
export interface Comment {
    author: User;
    post: Post;
    text: string;
}
```