### PR TITLE
Expand cross reference capabilities to type declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,20 +97,33 @@ Passing in a callback to the `t.interface` method will lazily populate the inter
 ```ts
 import { t } from "tanu.js";
 
-const User = t.interface("User", () => {
-  return {
-    users: t.array(User),
-    posts: t.array(Post),
-  };
+const User = t.interface("User", () => ({
+  users: t.array(User),
+  posts: t.array(Post),
+  authoredComments: t.array(Comment),
+}));
+
+const Post = t.interface("Post", () => ({
+  author: User,
+  text: t.string(),
+  images: t.array(t.string()),
+  postComments: t.array(Comment),
+}));
+
+const Comment = t.interface("Comment", {
+  author: User,
+  post: Post,
+  text: t.string(),
 });
 
-const Post = t.interface("Post", () => {
-  return {
-    author: User,
-  };
-});
+const CommentReply = t.type("CommentReply", () => ({
+  parent: CommentReply,
+  author: User,
+  post: Post,
+  text: t.string(),
+}));
 
-const result = await t.generate([User, Post]);
+const result = await t.generate([User, Post, Comment, CommentReply]);
 console.log(result);
 ```
 
@@ -120,8 +133,23 @@ console.log(result);
 export interface User {
   users: Array<User>;
   posts: Array<Post>;
+  authoredComments: Array<Comment>;
 }
 export interface Post {
   author: User;
+  text: string;
+  images: Array<string>;
+  postComments: Array<Comment>;
 }
+export interface Comment {
+  author: User;
+  post: Post;
+  text: string;
+}
+export type CommentReply = {
+  parent: CommentReply;
+  author: User;
+  post: Post;
+  text: string;
+};
 ```

--- a/src/type/declarations/interface.ts
+++ b/src/type/declarations/interface.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 
 import { TypeDefinitionObject } from "..";
+import { setLazy } from "../../utils";
 import { typeProperty } from "../utils";
 
 /**
@@ -36,15 +37,5 @@ function interface_(
 	properties: TypeDefinitionObject | (() => TypeDefinitionObject)
 ): ts.InterfaceDeclaration {
 	if (typeof properties !== "function") return constructInterface(name, properties);
-
-	let tentativeInterface = constructInterface(name, {});
-	setImmediate(() => {
-		tentativeInterface = constructInterface(name, properties());
-	});
-
-	return new Proxy(tentativeInterface, {
-		get(_, property, receiver) {
-			return Reflect.get(tentativeInterface, property, receiver);
-		}
-	});
+	return setLazy(constructInterface(name, {}), () => constructInterface(name, properties()));
 }

--- a/src/type/declarations/type.ts
+++ b/src/type/declarations/type.ts
@@ -1,15 +1,10 @@
 import * as ts from "typescript";
 
 import { TypeDefinition } from "..";
+import { setLazy } from "../../utils";
 import { toTypeNode } from "../utils";
 
-/**
- * Create an explicit type.
- *
- * @param name The type name.
- * @param definition The type definition.
- */
-export function type(name: string, definition: TypeDefinition): ts.TypeAliasDeclaration {
+const constructType = (name: string, definition: TypeDefinition) => {
 	return ts.factory.createTypeAliasDeclaration(
 		undefined,
 		[ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
@@ -17,4 +12,18 @@ export function type(name: string, definition: TypeDefinition): ts.TypeAliasDecl
 		undefined,
 		toTypeNode(definition)
 	);
+};
+
+/**
+ * Create an explicit type.
+ *
+ * @param name The type name.
+ * @param definition The type definition.
+ */
+export function type(
+	name: string,
+	definition: TypeDefinition | (() => TypeDefinition)
+): ts.TypeAliasDeclaration {
+	if (typeof definition !== "function") return constructType(name, definition);
+	return setLazy(constructType(name, {}), () => constructType(name, definition()));
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,3 +18,17 @@ export function isNode(value: unknown): value is ts.Node {
 		!!ts.SyntaxKind[(value as ts.Node).kind]
 	);
 }
+
+export function setLazy<T extends object>(defaultValue: T, immediateValue: () => T) {
+	let value = defaultValue;
+
+	setImmediate(() => {
+		value = immediateValue();
+	});
+
+	return new Proxy(defaultValue, {
+		get(_, property, receiver) {
+			return Reflect.get(value, property, receiver);
+		}
+	});
+}


### PR DESCRIPTION
This abstracts the lazy setting functionality by the `Proxy`, to `type` declarations as well.

```ts
import { t } from "tanu.js";

const User = t.interface("User", () => ({
  users: t.array(User),
  posts: t.array(Post),
  authoredComments: t.array(Comment),
}));

const Post = t.interface("Post", () => ({
  author: User,
  text: t.string(),
  images: t.array(t.string()),
  postComments: t.array(Comment),
}));

const Comment = t.interface("Comment", {
  author: User,
  post: Post,
  text: t.string(),
});

const CommentReply = t.type("CommentReply", () => ({
  parent: CommentReply,
  author: User,
  post: Post,
  text: t.string(),
}));
```

```ts
export interface User {
    users: Array<User>;
    posts: Array<Post>;
    authoredComments: Array<Comment>;
}
export interface Post {
    author: User;
    text: string;
    images: Array<string>;
    postComments: Array<Comment>;
}
export interface Comment {
    author: User;
    post: Post;
    text: string;
}
export type CommentReply = {
    parent: CommentReply;
    author: User;
    post: Post;
    text: string;
};
```