### PR TITLE
fix(declarations): export module as an alias to avoid CommonJS exports.export interference

### DIFF
--- a/src/type/declarations/interface.ts
+++ b/src/type/declarations/interface.ts
@@ -9,7 +9,6 @@ import { typeProperty } from "../utils";
  */
 function constructInterface(name: string, properties: TypeDefinitionObject) {
 	return ts.factory.createInterfaceDeclaration(
-		undefined,
 		[ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
 		name,
 		undefined,

--- a/src/type/declarations/module.ts
+++ b/src/type/declarations/module.ts
@@ -6,7 +6,7 @@ export interface ModuleOptions {
 	global?: boolean;
 }
 
-export function module(
+function module_(
 	name: string,
 	statements: Array<ts.InterfaceDeclaration | ts.ModuleDeclaration>,
 	options: ModuleOptions = {}
@@ -34,5 +34,10 @@ export function namespace(
 	statements: Array<ts.InterfaceDeclaration | ts.ModuleDeclaration>,
 	options: ModuleOptions = {}
 ): ts.ModuleDeclaration {
-	return module(name, statements, { ...options, namespace: true });
+	return module_(name, statements, { ...options, namespace: true });
 }
+
+/**
+ * `module` interferes with CommonJS `exports.module`.
+ */
+export { module_ as module };

--- a/src/type/declarations/module.ts
+++ b/src/type/declarations/module.ts
@@ -17,7 +17,6 @@ function module_(
 	if (options.namespace) flags |= ts.NodeFlags.Namespace;
 
 	return ts.factory.createModuleDeclaration(
-		undefined,
 		options.declare ? [ts.factory.createModifier(ts.SyntaxKind.DeclareKeyword)] : undefined,
 		ts.factory.createIdentifier(name),
 		ts.factory.createModuleBlock(statements),


### PR DESCRIPTION
The `module` is currently interfering with CJS `exports.module` when running with `bun`, so the following code:

```ts
import { t } from "tanu";

const User = t.interface("User", {
  id: t.number(),
  email: t.string(),
  name: t.optional({
    first: t.string(),
    last: t.string(),
  }),
});

const UserModule = t.namespace("User", [User]);
const App = t.module("App", [UserModule]);
```

Results in this runtime error:

```
1 | "use strict";
2 | Object.defineProperty(exports, "__esModule", { value: true });
3 | exports.namespace = exports.module = void 0;
4 | const tslib_1 = require("tslib");
5 | const ts = tslib_1.__importStar(require("typescript"));
6 | function module(name, statements, options = {}) {
    ^
SyntaxError: Cannot declare a let variable twice: 'module'.
      at <parse> (/Users/mozharovsky/Developer/github/tanu-bugfix/tanu/dist/type/declarations/module.js:6:1)
      at anonymous (native:1:1)
      at /Users/mozharovsky/Developer/github/tanu-bugfix/tanu/dist/type/declarations/index.js:6:1
      at anonymous (native:1:1)
      at /Users/mozharovsky/Developer/github/tanu-bugfix/tanu/dist/type/index.js:24:10
      at anonymous (native:1:1)
      at /Users/mozharovsky/Developer/github/tanu-bugfix/tanu/dist/runtime/index.js:14:5
      at anonymous (native:1:1)
      at /Users/mozharovsky/Developer/github/tanu-bugfix/tanu/dist/exports.js:4:1
      at anonymous (native:1:1)
      at /Users/mozharovsky/Developer/github/tanu-bugfix/tanu/dist/index.js:5:13
```

This PR:

* Fixes the interfering keywords issue
* Removes the deprecated decorators in typescript module and interface declarations